### PR TITLE
Update term.js to 0.0.7

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -29,7 +29,7 @@
     ],
     "dependencies": {
         "angular": ">=1.3.8 <1.5",
-        "term.js": "#0.0.3",
+        "term.js": "#0.0.7",
         "font-awesome": "*"
     },
     "devDependencies": {


### PR DESCRIPTION
Update term.js to 0.0.7, which includes fixes for mobile and copy/paste.

/cc @jwforres @stefwalter 
