### PR TITLE
Remove base1 from the AMD module dependencies

### DIFF
--- a/container-terminal.js
+++ b/container-terminal.js
@@ -19,7 +19,7 @@
 
 (function(root, factory) {
     if (typeof(define) === 'function' && define.amd)
-        define(["base1/angular", "base1/term" ], factory);
+        define(["angular", "term" ], factory);
     else
         factory(root.angular, root.Terminal);
 }(this, function(angular, Terminal) {

--- a/dist/container-terminal.js
+++ b/dist/container-terminal.js
@@ -19,7 +19,7 @@
 
 (function(root, factory) {
     if (typeof(define) === 'function' && define.amd)
-        define(["base1/angular", "base1/term" ], factory);
+        define(["angular", "term" ], factory);
     else
         factory(root.angular, root.Terminal);
 }(this, function(angular, Terminal) {


### PR DESCRIPTION
No longer necessary and this was Cockpit specific anyway.
