### PR TITLE
Publish terminal status attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,12 @@ and all the arguments. If not specified will default to running an interactive s
 If set to ```true``` then the widget will not start connecting automatically. It will
 wait for either user action or for the ```prevent``` flag to be cleared.
 
+#### =status
+
+Reports the connectivity status of the terminal back to the parent scope. The two
+states currently implemented are ```connected``` and ```disconnected```. This is
+not an input.
+
 #### Container Socket Service
 
 There is a container socket service that the terminal widget uses to create the

--- a/container-terminal.js
+++ b/container-terminal.js
@@ -82,9 +82,12 @@
                         rows: '=',
                         cols: '=',
                         screenKeys: '=',
-                        autofocus: '=?'
+                        autofocus: '=?',
+                        status: '='
                     },
                     link: function(scope, element, attrs) {
+                        scope.status = 'disconnected';
+
                         /* term.js wants the parent element to build its terminal inside of */
                         var outer = angular.element("<div class='terminal-wrapper'>");
                         element.append(outer);
@@ -159,6 +162,7 @@
                                 if (!first)
                                     message = "\r\n" + message;
                                 term.write('\x1b[31m' + message + '\x1b[m\r\n');
+                                scope.status = 'disconnected';
                                 scope.$apply(disconnect);
                             }
 
@@ -195,6 +199,7 @@
                                     };
 
                                     ws.onclose = function(ev) {
+                                        scope.status = 'disconnected';
                                         fatal(ev.reason);
                                     };
                                 },
@@ -202,9 +207,11 @@
                                     fatal(ex.message);
                                 }
                             );
+                            scope.status = 'connected';
                         }
 
                         function disconnect() {
+                            scope.status = 'disconnected';
                             spinner.addClass("hidden");
                             button.removeClass("hidden");
 

--- a/dist/container-terminal.js
+++ b/dist/container-terminal.js
@@ -82,9 +82,12 @@
                         rows: '=',
                         cols: '=',
                         screenKeys: '=',
-                        autofocus: '=?'
+                        autofocus: '=?',
+                        status: '='
                     },
                     link: function(scope, element, attrs) {
+                        scope.status = 'disconnected';
+
                         /* term.js wants the parent element to build its terminal inside of */
                         var outer = angular.element("<div class='terminal-wrapper'>");
                         element.append(outer);
@@ -159,6 +162,7 @@
                                 if (!first)
                                     message = "\r\n" + message;
                                 term.write('\x1b[31m' + message + '\x1b[m\r\n');
+                                scope.status = 'disconnected';
                                 scope.$apply(disconnect);
                             }
 
@@ -195,6 +199,7 @@
                                     };
 
                                     ws.onclose = function(ev) {
+                                        scope.status = 'disconnected';
                                         fatal(ev.reason);
                                     };
                                 },
@@ -202,9 +207,11 @@
                                     fatal(ex.message);
                                 }
                             );
+                            scope.status = 'connected';
                         }
 
                         function disconnect() {
+                            scope.status = 'disconnected';
                             spinner.addClass("hidden");
                             button.removeClass("hidden");
 


### PR DESCRIPTION
fixes #13 

Origin-web-console is making UI changes to how the user interacts with terminals to containers in a pod on openshift. In order to accurately reflect terminal state, a variable needed to be exposed to the view in order to make appropriate UI styling changes.

``` html
<div ng-repeat="term in containerTerminals">
     <kubernetes-container-terminal
          prevent="!terminalTabWasSelected"
          ng-if="term.isUsed"
          ng-show="term.isActive"
          pod="pod"
          container="term.name"
          status="term.status">
     </kubernetes-container-terminal>
</div>
```

@benjaminapetersen 
