### PR TITLE
Resize correct terminal when more than one is on the page

### DIFF
--- a/container-terminal.js
+++ b/container-terminal.js
@@ -129,7 +129,7 @@
                           if (!term.charMeasure.width) {
                             return;
                           }
-                          var xtermViewport = document.getElementsByClassName("xterm-viewport")[0];
+                          var xtermViewport = element[0].getElementsByClassName("xterm-viewport")[0];
                           // character width * number of columns + space for a scrollbar
                           // TODO determine the max width of a scrollbar across browsers
                           xtermViewport.style.width = (term.charMeasure.width * cols + 17) + "px";

--- a/dist/container-terminal.js
+++ b/dist/container-terminal.js
@@ -129,7 +129,7 @@
                           if (!term.charMeasure.width) {
                             return;
                           }
-                          var xtermViewport = document.getElementsByClassName("xterm-viewport")[0];
+                          var xtermViewport = element[0].getElementsByClassName("xterm-viewport")[0];
                           // character width * number of columns + space for a scrollbar
                           // TODO determine the max width of a scrollbar across browsers
                           xtermViewport.style.width = (term.charMeasure.width * cols + 17) + "px";


### PR DESCRIPTION
We were always resizing the first `.xterm-viewport` on the page. We should look for the child of the element for this directive.

@stefwalter @rhamilto PTAL