### PR TITLE
Version 2.1.0

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
     "name": "kubernetes-container-terminal",
-    "version": "2.0.2",
+    "version": "2.1.0",
     "description": "Provides a terminal for a kubernetes container in a pod.",
     "moduleType": [
         "globals"
@@ -29,7 +29,7 @@
     ],
     "dependencies": {
         "angular": ">=1.3.8 <1.6",
-        "xterm.js": "#2.8.0",
+        "xterm.js": "^2.9.0",
         "font-awesome": "*"
     },
     "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "kubernetes-container-terminal",
   "description": "Provides a terminal for a kubernetes container in a pod.",
   "author": "Stef Walter",
-  "version": "2.0.2",
+  "version": "2.1.0",
   "license": "LGPL 2+",
   "main": "dist/container-terminal.js",
   "devDependencies": {
@@ -16,5 +16,10 @@
     "grunt-contrib-concat": "~0.5.1",
     "grunt-contrib-uglify": "*",
     "grunt-run": "*"
+  },
+  "dependencies": {
+    "angular": ">=1.3.8 <1.6",
+    "xterm": "^2.9.0",
+    "font-awesome": "*"
   }
 }


### PR DESCRIPTION
* Bump xterm.js to 2.9.0
* Add dependencies stanza to package.json

https://github.com/sourcelair/xterm.js/releases/tag/2.9.0

@petervo PTAL
@stefwalter CC