### PR TITLE
Only respect prevent argument until connected

### DIFF
--- a/container-terminal.js
+++ b/container-terminal.js
@@ -105,6 +105,9 @@
                         var defaultCols = 80;
                         var defaultRows = 24;
 
+                        /* Whether the component is preventing a connection */
+                        var preventing = true;
+
                         var term = new Terminal({
                             cols: scope.cols || defaultCols,
                             rows: scope.rows || defaultRows,
@@ -148,6 +151,7 @@
                         };
 
                         function connect() {
+                            preventing = false;
                             disconnect();
 
                             term.reset();
@@ -265,7 +269,7 @@
                         scope.$watchGroup(["cols", "rows"], sizeTerminal);
 
                         scope.$watch("prevent", function(prevent) {
-                            if (!prevent)
+                            if (!prevent && preventing)
                                 connect();
                         });
 


### PR DESCRIPTION
Once we're connected, either explicitly or due to to the button
click, we should no longer respect the prevent option or reconnect
when it cycles.